### PR TITLE
127 tactics set timing over counting

### DIFF
--- a/src/app/components/training/tactics/TacticsTrainer.tsx
+++ b/src/app/components/training/tactics/TacticsTrainer.tsx
@@ -311,13 +311,6 @@ export default function TacticsTrainer(props: {
   })
 
   const exit = async () => {
-    const newTime = Date.now()
-    increaseTimeTaken.mutate({
-      roundId: currentRound.id,
-      timeTaken: (newTime - startTime) / 1000,
-      setId: props.set.id,
-    })
-    setStartTime(newTime)
     queryClient.invalidateQueries({ queryKey: ['tactics', 'sets'] })
     trackEventOnClient('tactics_set_closed', {})
     router.push('/training/tactics/list')

--- a/src/app/components/training/tactics/TacticsTrainer.tsx
+++ b/src/app/components/training/tactics/TacticsTrainer.tsx
@@ -79,7 +79,7 @@ export default function TacticsTrainer(props: {
   // Setup state for the game and training
   const [readyForInput, setReadyForInput] = useState(false)
   const [puzzleFinished, setPuzzleFinished] = useState(false)
-  const [startTime] = useState(Date.now())
+  const [startTime, setStartTime] = useState(Date.now())
   const [sessionTimeStarted] = useState(new Date())
   const [puzzleStatus, setPuzzleStatus] = useState<
     'none' | 'correct' | 'incorrect'
@@ -181,11 +181,14 @@ export default function TacticsTrainer(props: {
       setPuzzleFinished(true)
       setXpCounter(xpCounter + 1)
 
+      const newTime = Date.now()
       increaseTimeTaken.mutate({
         roundId: currentRound.id,
-        timeTaken: (Date.now() - startTime) / 1000,
+        timeTaken: (newTime - startTime) / 1000,
         setId: props.set.id,
       })
+      setStartTime(newTime)
+
       increaseCorrect.mutate({
         roundId: currentRound.id,
         currentStreak: currentStreak + 1,
@@ -252,7 +255,7 @@ export default function TacticsTrainer(props: {
         ...currentRound,
         incorrect: currentRound.incorrect + 1,
       })
-      
+
       return false
     }
     setPosition(game.fen())
@@ -308,11 +311,13 @@ export default function TacticsTrainer(props: {
   })
 
   const exit = async () => {
+    const newTime = Date.now()
     increaseTimeTaken.mutate({
       roundId: currentRound.id,
-      timeTaken: (Date.now() - startTime) / 1000,
+      timeTaken: (newTime - startTime) / 1000,
       setId: props.set.id,
     })
+    setStartTime(newTime)
     queryClient.invalidateQueries({ queryKey: ['tactics', 'sets'] })
     trackEventOnClient('tactics_set_closed', {})
     router.push('/training/tactics/list')
@@ -372,16 +377,18 @@ export default function TacticsTrainer(props: {
 
   return (
     <div className="relative border border-gray-300 dark:text-white dark:border-slate-600 shadow-md dark:shadow-slate-900 bg-[rgba(0,0,0,0.03)] dark:bg-[rgba(255,255,255,0.03)]">
-      {// Check if any queries are loading
-      (puzzleQuery.isFetching ||
-        increaseCorrect.isPending ||
-        increaseIncorrect.isPending ||
-        increaseTimeTaken.isPending ||
-        createRound.isPending) && (
-        <div className="absolute inset-0 z-50 grid place-items-center bg-[rgba(0,0,0,0.3)]">
-          <Spinner />
-        </div>
-      )}
+      {
+        // Check if any queries are loading
+        (puzzleQuery.isFetching ||
+          increaseCorrect.isPending ||
+          increaseIncorrect.isPending ||
+          increaseTimeTaken.isPending ||
+          createRound.isPending) && (
+          <div className="absolute inset-0 z-50 grid place-items-center bg-[rgba(0,0,0,0.3)]">
+            <Spinner />
+          </div>
+        )
+      }
       <div className="flex flex-wrap items-center justify-between px-2 py-1 border-b border-gray-300 dark:border-slate-600 font-bold text-orange-500">
         <p className="text-lg font-bold">{props.set.name}</p>
         <div className="flex items-center gap-2 text-black dark:text-white">


### PR DESCRIPTION
Fixes issue #127 

This pull request updates the tactics trainer component to improve how puzzle timing is tracked and reported, and cleans up some code related to time tracking on exit. The most important changes are grouped below.

**Puzzle timing and state management:**

* Changed `startTime` to use a setter (`setStartTime`) so it can be updated after each puzzle, allowing for accurate tracking of time spent per puzzle.
* After a correct answer, the time taken for the puzzle is now calculated using a fresh timestamp (`newTime`), and `startTime` is reset for the next puzzle. This ensures each puzzle's time is measured independently.

**Code cleanup:**

* Removed the call to `increaseTimeTaken.mutate` from the `exit` function, so time is only tracked per puzzle and not redundantly on exit.

**Minor UI/comment updates:**

* Improved comment formatting for the loading spinner conditional and fixed its indentation for clarity. [[1]](diffhunk://#diff-5e258e2c7b983c33001cb2cca94781092999d9355c9c88096823f1cc829bd623L375-R374) [[2]](diffhunk://#diff-5e258e2c7b983c33001cb2cca94781092999d9355c9c88096823f1cc829bd623L384-R384)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved accuracy of time tracking for tactics puzzles by consistently capturing and resetting timestamps.
  - Prevented incorrect time records when exiting a puzzle by removing the previous exit-time mutation.
  - Loading indicator behavior refined so it reflects puzzle fetching and round creation more reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->